### PR TITLE
Return equalities from facet enumeration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,4 +89,8 @@ codegen/
 # Octave session info
 octave-workspace
 
+# Visual studio (code)
+.vs/
+.vscode/
+
 # End of https://www.toptal.com/developers/gitignore/api/matlab,cmake,c++

--- a/GeoCalcLibTest.m
+++ b/GeoCalcLibTest.m
@@ -65,6 +65,17 @@ classdef GeoCalcLibTest < matlab.unittest.TestCase
                 testCase.verifyTrue(any(all([b,A]==hyperplane',2)),"Hyperplanes do not match expected ones.");
             end
         end
+
+        function testLinearities(testCase)
+            V = 3*eye(2);
+            [Aineq,bineq,Aeq,beq] = facetEnumeration(V);
+            testCase.verifyEqual(size(Aineq,1),2,"Number of inequalities");
+            testCase.verifyLessThanOrEqual(Aineq*V(:,1),bineq,"Inequalities");
+            testCase.verifyLessThanOrEqual(Aineq*V(:,2),bineq,"Inequalities");
+            testCase.verifyEqual(size(Aeq,1),1, "Number of linearities");
+            testCase.verifyEqual(Aeq*V(:,1),beq,"Linearity");
+            testCase.verifyEqual(Aeq*V(:,2),beq,"Linearity");
+        end
     end
     
 end

--- a/core/include/lrsinterface.hpp
+++ b/core/include/lrsinterface.hpp
@@ -94,5 +94,17 @@ class Polytope {
             return HrepIneq.col(0);
         }
 
+        MatrixXq getAeq(void) {
+            if (!inHrep)
+                facetEnumerate();
+            return HrepEq.block(0, 1, HrepEq.rows(), HrepEq.cols() - 1);
+        }
+
+        MatrixXq getBeq(void) {
+            if (!inHrep)
+                facetEnumerate();
+            return HrepEq.col(0);
+        }
+
         
 };

--- a/src/facetEnumeration.cpp
+++ b/src/facetEnumeration.cpp
@@ -40,5 +40,11 @@ public:
         if (outputs.size()>1)
             outputs[1] = utilities::eigen::convert(fromMatrixXq(poly.getB()));
 
+        if (outputs.size() > 2)
+            outputs[2] = utilities::eigen::convert(fromMatrixXq(poly.getAeq()));
+
+        if (outputs.size() > 3)
+            outputs[3] = utilities::eigen::convert(fromMatrixXq(poly.getBeq()));
+
     }
 };


### PR DESCRIPTION
This PR adds the ability to obtain the inequalities supporting a polyhedron as well as equalities required to correctly characterise the polyhedron. Technically, a bug fix.. It also adds a unit test for the linearities.